### PR TITLE
Adjusting how the callback is called in list_comment

### DIFF
--- a/includes/comments-functions.php
+++ b/includes/comments-functions.php
@@ -48,7 +48,7 @@ class CGB_Comments_Functions {
 			}
 		}
 		//comment callback function
-		if('' === $this->options->get('cgb_comment_adjust') && function_exists($this->options->get('cgb_comment_adjust'))) {
+		if('' !== $this->options->get('cgb_comment_adjust')) {
 			$args['callback'] = $this->options->get('cgb_comment_callback');
 		}
 		else {


### PR DESCRIPTION
I couldn't set a callback value in backend, and I think it's the "function_exists" who is the issue here, because it would always be false, because it's a value and not a function we are checking for. By adjust the statements I could get it to work.
A awesome plugin, btw!
