### PR TITLE
Keep widget content out of google indexing

### DIFF
--- a/includes/widget.php
+++ b/includes/widget.php
@@ -101,6 +101,7 @@ class CGB_Widget extends WP_Widget {
 			$out .= $before_title . $instance['title'] . $after_title;
 		}
 		$out .= '
+				<!--googleoff: all-->
 				<ul class="cgb-widget">';
 		if($comments) {
 			// Prime cache for associated posts. (Prime post term cache if we need it for permalinks.)
@@ -138,6 +139,7 @@ class CGB_Widget extends WP_Widget {
 		}
 		$out .= '
 				</ul>
+				<!--googleon: all>
 				';
 		if('true' === $instance['link_to_page']) {
 			$out .= '


### PR DESCRIPTION
After installing widget on all pages, my name became very popular on google. Too popular. 

https://www.google.com/support/enterprise/static/gsa/docs/admin/70/gsa_doc_set/admin_crawl/preparing.html#1076243 covers the tag's effect. 